### PR TITLE
V2.10.0 new proxy engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp
 optimize/*
 public/styles.css
 main
+gothicframework

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ tmp
 optimize/*
 public/styles.css
 main
+main.exe
 gothicframework
+gothicframework.exe

--- a/cmd/hotReload.go
+++ b/cmd/hotReload.go
@@ -97,7 +97,7 @@ func (command *HotReloadCommand) HotReload() error {
 🔥  Mode: HOT RELOAD ENABLED
 `
 	fmt.Println(banner)
-
+	command.openBrowser("http://127.0.0.1:3000")
 	select {}
 
 }
@@ -260,4 +260,21 @@ func (command *HotReloadCommand) rebuild() {
 		}
 	}()
 
+}
+
+func (command *HotReloadCommand) openBrowser(url string) error {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	default:
+		return nil
+	}
+
+	return cmd.Start()
 }

--- a/cmd/hotReload.go
+++ b/cmd/hotReload.go
@@ -19,6 +19,7 @@ import (
 
 	gothic_cli "github.com/felipegenef/gothicframework/pkg/cli"
 	"github.com/fsnotify/fsnotify"
+	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 )
 
@@ -73,7 +74,12 @@ func newHotReloadCommand(cli gothic_cli.GothicCli) RunEFunc {
 }
 
 func (command *HotReloadCommand) HotReload() error {
-	targetURL, err := url.Parse("http://localhost:8080")
+	godotenv.Load()
+	port := os.Getenv("HTTP_LISTEN_ADDR")
+	if port == "" {
+		port = ":8080"
+	}
+	targetURL, err := url.Parse("http://localhost" + port)
 	if err != nil {
 		log.Fatalf("Invalid target URL: %v", err)
 	}
@@ -81,7 +87,6 @@ func (command *HotReloadCommand) HotReload() error {
 	// Wait for tailwind process to render css for the first time
 	time.Sleep(4 * time.Second)
 	go command.watchForChanges()
-	// go command.watchTemplChanges()
 	go command.cli.Proxy.RunProxy("localhost", 3000, targetURL)
 
 	banner := `

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -50,7 +50,7 @@ func NewCli() GothicCli {
 		AWS:             helpers.NewAwsHelper(),
 		Logger:          helpers.NewLogger("error", false, os.Stdout),
 		FileBasedRouter: routes.NewFileBasedRouteHelper(),
-		Proxy:           proxy.NewProxy(),
+		Proxy:           proxy.NewProxyHelper(),
 	}
 
 	return cli

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 
 	helpers "github.com/felipegenef/gothicframework/pkg/helpers"
+	proxy "github.com/felipegenef/gothicframework/pkg/helpers/proxy"
 	routes "github.com/felipegenef/gothicframework/pkg/helpers/routes"
 )
 
@@ -25,6 +26,7 @@ type GothicCli struct {
 	AwsSam          helpers.AwsSamHelper
 	AWS             helpers.AwsHelper
 	FileBasedRouter routes.FileBasedRouteHelper
+	Proxy           proxy.ProxyHelper
 }
 
 type CliCommands struct {
@@ -40,7 +42,6 @@ type CliCommands struct {
 
 func NewCli() GothicCli {
 	cli := GothicCli{
-
 		Runtime:         runtime.GOOS,
 		Templates:       helpers.NewTemplateHelper(),
 		Tailwind:        helpers.NewTailwindHelper(),
@@ -49,6 +50,7 @@ func NewCli() GothicCli {
 		AWS:             helpers.NewAwsHelper(),
 		Logger:          helpers.NewLogger("error", false, os.Stdout),
 		FileBasedRouter: routes.NewFileBasedRouteHelper(),
+		Proxy:           proxy.NewProxy(),
 	}
 
 	return cli

--- a/pkg/helpers/proxy/proxy.go
+++ b/pkg/helpers/proxy/proxy.go
@@ -233,15 +233,12 @@ func (rt *roundTripper) setShouldSkipResponseModificationHeader(r *http.Request,
 // Modify response to inject script and handle encoding
 func (proxy *ProxyHelper) modifyResponse(r *http.Response) error {
 	urlStr := r.Request.URL.String()
-	log.Printf("Modifying response for URL: %s", urlStr)
 
 	if r.Header.Get("gothic-framework-skip-modify") == "true" {
-		log.Printf("Skipping response modification for %s due to header", urlStr)
 		return nil
 	}
 
 	if !strings.HasPrefix(r.Header.Get("Content-Type"), "text/html") {
-		log.Printf("Skipping response modification for %s: not HTML (Content-Type: %s)", urlStr, r.Header.Get("Content-Type"))
 		return nil
 	}
 
@@ -255,10 +252,6 @@ func (proxy *ProxyHelper) modifyResponse(r *http.Response) error {
 	case "br":
 		newReader = func(in io.Reader) (io.Reader, error) { return brotli.NewReader(in), nil }
 		newWriter = func(out io.Writer) io.WriteCloser { return brotli.NewWriter(out) }
-	case "":
-		log.Printf("No content encoding for %s", urlStr)
-	default:
-		log.Printf("%s (encoding: %s)", unsupportedContentEncoding, r.Header.Get("Content-Encoding"))
 	}
 
 	encr, err := newReader(r.Body)

--- a/pkg/helpers/proxy/proxy.go
+++ b/pkg/helpers/proxy/proxy.go
@@ -1,0 +1,396 @@
+package proxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/andybalholm/brotli"
+	"golang.org/x/net/html"
+
+	_ "embed"
+)
+
+//go:embed script.js
+var reloadScriptJS string
+
+var errBodyNotFound = fmt.Errorf("body not found")
+
+const unsupportedContentEncoding = "Unsupported content encoding, hot reload script not inserted."
+
+type ProxyHelper struct {
+	URL    string
+	Target *url.URL
+	p      *httputil.ReverseProxy
+	Sse    *SSEHandler
+}
+
+// RoundTripper with retries
+type roundTripper struct {
+	maxRetries      int
+	initialDelay    time.Duration
+	backoffExponent float64
+}
+
+// SSE event and handler (migrated from the sse package)
+
+type event struct {
+	Type string
+	Data string
+}
+
+type SSEHandler struct {
+	m        *sync.Mutex
+	counter  int64
+	requests map[int64]chan event
+}
+
+func NewProxy() ProxyHelper {
+	return ProxyHelper{
+		Sse: NewSSEHandler(),
+	}
+}
+
+func NewSSEHandler() *SSEHandler {
+	return &SSEHandler{
+		m:        new(sync.Mutex),
+		requests: make(map[int64]chan event),
+	}
+}
+
+// RunProxy configures and starts the proxy server with bind, port, and target
+func (proxy *ProxyHelper) RunProxy(bind string, port int, target *url.URL) {
+	proxy.Target = target
+	proxy.URL = fmt.Sprintf("http://%s:%d", bind, port)
+
+	p := httputil.NewSingleHostReverseProxy(target)
+	p.ErrorLog = log.New(os.Stderr, "Proxy error: ", 0)
+	p.Transport = &roundTripper{
+		maxRetries:      20,
+		initialDelay:    100 * time.Millisecond,
+		backoffExponent: 1.5,
+	}
+
+	proxy.p = p
+	proxy.p.ModifyResponse = proxy.modifyResponse
+
+	log.Printf("Starting proxy at %s -> %s\n", proxy.URL, target)
+
+	err := http.ListenAndServe(fmt.Sprintf("%s:%d", bind, port), proxy)
+	if err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
+}
+
+// ServeHTTP handles internal routes and normal proxying
+func (proxy *ProxyHelper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/_gothicframework/reload/script.js":
+		w.Header().Add("Content-Type", "text/javascript")
+		_, err := io.WriteString(w, reloadScriptJS)
+		if err != nil {
+			log.Printf("failed to write script: %v\n", err)
+		}
+		return
+
+	case "/_gothicframework/reload/events":
+		switch r.Method {
+		case http.MethodGet:
+			proxy.Sse.ServeHTTP(w, r)
+		case http.MethodPost:
+			proxy.Sse.Send("message", "reload")
+		default:
+			http.Error(w, "only GET or POST method allowed", http.StatusMethodNotAllowed)
+		}
+		return
+	}
+
+	proxy.p.ServeHTTP(w, r)
+}
+
+// SSE methods
+
+func (s *SSEHandler) Send(eventType string, data string) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	for _, ch := range s.requests {
+		ch := ch
+		go func(ch chan event) {
+			ch <- event{
+				Type: eventType,
+				Data: data,
+			}
+		}(ch)
+	}
+}
+
+func (s *SSEHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	id := atomic.AddInt64(&s.counter, 1)
+	s.m.Lock()
+	events := make(chan event)
+	s.requests[id] = events
+	s.m.Unlock()
+	defer func() {
+		s.m.Lock()
+		defer s.m.Unlock()
+		delete(s.requests, id)
+		close(events)
+	}()
+
+	timer := time.NewTimer(0)
+loop:
+	for {
+		select {
+		case <-timer.C:
+			if _, err := fmt.Fprintf(w, "event: message\ndata: ping\n\n"); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			timer.Reset(time.Second * 5)
+		case e := <-events:
+			if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", e.Type, e.Data); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		case <-r.Context().Done():
+			break loop
+		}
+		w.(http.Flusher).Flush()
+	}
+}
+
+// NotifyProxy helper to send reload via POST
+func NotifyProxy(host string, port int) error {
+	urlStr := fmt.Sprintf("http://%s:%d/_gothicframework/reload/events", host, port)
+	req, err := http.NewRequest(http.MethodPost, urlStr, nil)
+	if err != nil {
+		return err
+	}
+	_, err = http.DefaultClient.Do(req)
+	return err
+}
+
+// SSE send via ProxyHelper
+func (proxy *ProxyHelper) SendSSE(eventType, data string) {
+	proxy.Sse.Send(eventType, data)
+}
+
+// RoundTripper with retry and exponential backoff
+func (rt *roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	var bodyBytes []byte
+	if r.Body != nil && r.Body != http.NoBody {
+		var err error
+		bodyBytes, err = io.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		r.Body.Close()
+	}
+
+	var resp *http.Response
+	var err error
+	for retries := 0; retries < rt.maxRetries; retries++ {
+		req := r.Clone(r.Context())
+		if bodyBytes != nil {
+			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
+		resp, err = http.DefaultTransport.RoundTrip(req)
+		if err != nil {
+			time.Sleep(rt.initialDelay * time.Duration(math.Pow(rt.backoffExponent, float64(retries))))
+			continue
+		}
+		rt.setShouldSkipResponseModificationHeader(r, resp)
+		return resp, nil
+	}
+
+	return nil, fmt.Errorf("max retries reached for URL: %q", r.URL.String())
+}
+
+func (rt *roundTripper) setShouldSkipResponseModificationHeader(r *http.Request, resp *http.Response) {
+	if r.Header.Get("HX-Request") == "true" {
+		resp.Header.Set("gothic-framework-skip-modify", "true")
+	}
+}
+
+// Modify response to inject script and handle encoding
+func (proxy *ProxyHelper) modifyResponse(r *http.Response) error {
+	urlStr := r.Request.URL.String()
+	log.Printf("Modifying response for URL: %s", urlStr)
+
+	if r.Header.Get("gothic-framework-skip-modify") == "true" {
+		log.Printf("Skipping response modification for %s due to header", urlStr)
+		return nil
+	}
+
+	if !strings.HasPrefix(r.Header.Get("Content-Type"), "text/html") {
+		log.Printf("Skipping response modification for %s: not HTML (Content-Type: %s)", urlStr, r.Header.Get("Content-Type"))
+		return nil
+	}
+
+	newReader := func(in io.Reader) (io.Reader, error) { return in, nil }
+	newWriter := func(out io.Writer) io.WriteCloser { return passthroughWriteCloser{out} }
+
+	switch r.Header.Get("Content-Encoding") {
+	case "gzip":
+		newReader = func(in io.Reader) (io.Reader, error) { return gzip.NewReader(in) }
+		newWriter = func(out io.Writer) io.WriteCloser { return gzip.NewWriter(out) }
+	case "br":
+		newReader = func(in io.Reader) (io.Reader, error) { return brotli.NewReader(in), nil }
+		newWriter = func(out io.Writer) io.WriteCloser { return brotli.NewWriter(out) }
+	case "":
+		log.Printf("No content encoding for %s", urlStr)
+	default:
+		log.Printf("%s (encoding: %s)", unsupportedContentEncoding, r.Header.Get("Content-Encoding"))
+	}
+
+	encr, err := newReader(r.Body)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	body, err := io.ReadAll(encr)
+	if err != nil {
+		return err
+	}
+
+	csp := r.Header.Get("Content-Security-Policy")
+	updated, err := proxy.insertScriptTagIntoBody(proxy.parseNonce(csp), string(body))
+	if err != nil {
+		log.Printf("Unable to insert reload script for %s: %v", urlStr, err)
+		updated = string(body)
+	}
+
+	var buf bytes.Buffer
+	writer := newWriter(&buf)
+	_, err = writer.Write([]byte(updated))
+	if err != nil {
+		return err
+	}
+	if err = writer.Close(); err != nil {
+		return err
+	}
+
+	r.Body = io.NopCloser(&buf)
+	r.ContentLength = int64(buf.Len())
+	r.Header.Set("Content-Length", strconv.Itoa(buf.Len()))
+
+	return nil
+}
+
+// passthrough helper to write without closing the Writer
+type passthroughWriteCloser struct {
+	io.Writer
+}
+
+func (pwc passthroughWriteCloser) Close() error {
+	return nil
+}
+
+// Helpers to manipulate HTML and inject script
+
+func (proxy *ProxyHelper) parseNonce(csp string) string {
+	for _, raw := range strings.Split(csp, ";") {
+		parts := strings.Fields(raw)
+		if len(parts) < 2 || parts[0] != "script-src" {
+			continue
+		}
+		for _, part := range parts[1:] {
+			part = strings.Trim(part, "'")
+			if strings.HasPrefix(part, "nonce-") {
+				return part[6:]
+			}
+		}
+	}
+	return ""
+}
+
+func (proxy *ProxyHelper) insertScriptTagIntoBody(nonce, body string) (string, error) {
+	doc, err := html.Parse(strings.NewReader(body))
+	if err != nil {
+		return body, err
+	}
+	bodyNodes := proxy.all(doc, proxy.element("body"))
+	if len(bodyNodes) == 0 {
+		return body, errBodyNotFound
+	}
+	bodyNodes[0].AppendChild(proxy.newReloadScriptNode(nonce))
+
+	var buf bytes.Buffer
+	if err := html.Render(&buf, doc); err != nil {
+		return body, err
+	}
+	return buf.String(), nil
+}
+
+func (proxy *ProxyHelper) newReloadScriptNode(nonce string) *html.Node {
+	script := &html.Node{
+		Type: html.ElementNode,
+		Data: "script",
+		Attr: []html.Attribute{
+			{Key: "src", Val: "/_gothicframework/reload/script.js"},
+		},
+	}
+	if nonce != "" {
+		script.Attr = append(script.Attr, html.Attribute{Key: "nonce", Val: nonce})
+	}
+	return script
+}
+
+type matcher func(*html.Node) bool
+
+type attribute struct {
+	Name, Value string
+}
+
+func (proxy *ProxyHelper) element(name string, attrs ...attribute) matcher {
+	return func(n *html.Node) bool {
+		if n.Type != html.ElementNode || n.Data != name {
+			return false
+		}
+		for _, a := range attrs {
+			if proxy.getAttrValue(n, a.Name) != a.Value {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func (proxy *ProxyHelper) all(n *html.Node, f matcher) []*html.Node {
+	var nodes []*html.Node
+	if f(n) {
+		nodes = append(nodes, n)
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		nodes = append(nodes, proxy.all(c, f)...)
+	}
+	return nodes
+}
+
+func (proxy *ProxyHelper) getAttrValue(n *html.Node, name string) string {
+	for _, a := range n.Attr {
+		if a.Key == name {
+			return a.Val
+		}
+	}
+	return ""
+}

--- a/pkg/helpers/proxy/script.js
+++ b/pkg/helpers/proxy/script.js
@@ -1,0 +1,10 @@
+(function() {
+    let gothicframework_reloadSrc = window.gothicframework_reloadSrc || new EventSource("/_gothicframework/reload/events");
+    gothicframework_reloadSrc.onmessage = (event) => {
+      if (event && event.data === "reload") {
+        window.location.reload();
+      }
+    };
+    window.gothicframework_reloadSrc = gothicframework_reloadSrc;
+    window.onbeforeunload = () => window.gothicframework_reloadSrc.close();
+  })();

--- a/pkg/helpers/templ.go
+++ b/pkg/helpers/templ.go
@@ -23,15 +23,3 @@ func (t *TemplHelper) Render() error {
 	}
 	return nil
 }
-
-func (helper *TemplHelper) Watch() error {
-	go func() {
-		logger := NewLogger("error", false, os.Stdout)
-
-		templ.Run(context.Background(), logger, templ.Arguments{
-			Watch: true,
-			Proxy: "http://localhost:8080",
-		})
-	}()
-	return nil
-}


### PR DESCRIPTION
# Feature

- Implemented a custom reverse proxy server with SSE support for hot reload.  
  The existing solution (`a-h/templ`) brought in heavy dependencies, especially affecting the `--watch --proxy` command performance, causing slower hot reloads. Additionally, unrelated logs from TensorFlow appeared due to `github.com/pkg/browser`.  
  To address this, we created our own lightweight fork of the `templ` proxy, simplifying the setup and using native OS commands to open the browser.

- Changed the hot reload proxy port from `7331` to `3000` to align with common standards used by React and Next.js.
- Updated the proxy to dynamically follow the server port by leveraging the `HTTP_LISTEN_ADDR` environment variable.